### PR TITLE
Border and padding

### DIFF
--- a/src/components/Recipe.js
+++ b/src/components/Recipe.js
@@ -3,7 +3,14 @@ import React from "react";
 function Recipe(props) {
   const recipe = props.recipe;
   return (
-    <div style={{ width: "50%", padding: 25 }}>
+    <div
+      style={{
+        width: "50%",
+        padding: 25,
+        margin: 10,
+        border: "5px solid green",
+      }}
+    >
       <h2>{recipe.title}</h2>
       <img src={recipe.img} alt="recipe" width="150" height="150" />
       <h3>Ingredients</h3>

--- a/src/pages/RecipesPage.js
+++ b/src/pages/RecipesPage.js
@@ -54,7 +54,7 @@ function RecipesPage() {
 
   return (
     <div style={{ backgroundColor: "beige" }}>
-      <h1>Your Recipes</h1>
+      <h1 style={{ margin: 0, padding: 20 }}>Your Recipes</h1>
       <div style={{ display: "flex" }}>
         {recipe.map((value, index) => {
           return <Recipe recipe={value} key={index} />;


### PR DESCRIPTION
Making 2 commits here!

First commit adds a solid green border around the recipe cards in `Recipe.js`, should be easy to change depending on color, style, width you'd want for the actual workshop.

Second commit fixes the random white strip that was appearing at the top of the page by eliminating default margins on `<h1>` tag and adding some padding for \~aesthetics\~.

# Preview:
<img width="1268" alt="Screen Shot 2020-09-27 at 2 33 28 PM" src="https://user-images.githubusercontent.com/35875225/94373945-6f917a00-00ce-11eb-85c0-c0d0722a008c.png">
